### PR TITLE
1，数组方式配置公众号的AesKey改为aeskey，大写的有问题。2，getCookieParams获取不到微信事件消息数据，改为get…

### DIFF
--- a/App/HttpController/WeChatEvent.php
+++ b/App/HttpController/WeChatEvent.php
@@ -23,7 +23,7 @@ class WeChatEvent extends Controller
     public function onOfficialAccountGet()
     {
         // 将微信发来的 params 参数创建为 AccessCheck Bean对象
-        $accessCheckBean = new AccessCheck($this->request()->getCookieParams());
+        $accessCheckBean = new AccessCheck($this->request()->getRequestParam());
 
         // 使用名为 'default' WeChat 对象进行验证
         $verify = WeChatManager::getInstance()->weChat('default')->officialAccount()->server()->accessCheck($accessCheckBean);
@@ -45,7 +45,7 @@ class WeChatEvent extends Controller
     public function onOfficialAccountPost()
     {
         // 将微信发来的 params 参数创建为 AccessCheck Bean对象
-        $accessCheckBean = new AccessCheck($this->request()->getCookieParams());
+        $accessCheckBean = new AccessCheck($this->request()->getRequestParam());
 
         // 使用名为 'default' WeChat 对象进行验证
         $verify = WeChatManager::getInstance()->weChat('default')->officialAccount()->server()->accessCheck($accessCheckBean);

--- a/EasySwooleEvent.php
+++ b/EasySwooleEvent.php
@@ -39,7 +39,7 @@ class EasySwooleEvent implements Event
             'appId'     => 'you appId',
             'appSecret' => 'you appSecret',
             'token'     => 'you token',
-            'AesKey'    => 'you AesKey',
+            'aesKey'    => 'you AesKey',
         ];
         $weChatConfig->officialAccount($configArray);
 


### PR DESCRIPTION
1，数组方式配置公众号的AesKey改为aeskey，大写的有问题。
2，getCookieParams获取不到微信事件消息数据，改为get…